### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ A security tool that aim at doing the following
 # Tested OSes
 * Debian
 * Ubuntu
+* Arch
+* Void
+* Parabola
 
 # How to use (ubuntu)
 * sudo apt-get install python3 python3-pip


### PR DESCRIPTION
added some other OSes I've tested on, debian method (sans apt-get; substitute xbps-install and pacman/yaourt respectively) is pretty much applicable otherwise
